### PR TITLE
make task closes idempotent

### DIFF
--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import lombok.extern.slf4j.Slf4j;
@@ -237,7 +238,11 @@ public class BigqueryStorageWriteSinkTask extends SinkTask {
   @Override
   public void close(Collection<TopicPartition> partitions) {
     super.close(partitions);
-    partitions.forEach(tp -> topicPartitionWriters.get(tp).close());
+    // NOTE: Handle potential multiple invocations of close() by treating map entries as Optional,
+    // since the map may have already been cleared in a prior call.
+    partitions.forEach(
+        tp ->
+            Optional.ofNullable(topicPartitionWriters.get(tp)).ifPresent(writer -> writer.close()));
     topicPartitionWriters.clear();
     log.trace("task.close: {}", partitions);
   }


### PR DESCRIPTION
Summary
---

In some cases, the close method of a task could be invoked multiple times, leading to a NullPointerException when attempting to close a non-existent writer.
This has been fixed by modifying the logic so that the close method is only called if the corresponding writer exists.