### PR TITLE
make task flushing idempotent

### DIFF
--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
@@ -123,9 +123,12 @@ public class BigqueryStorageWriteSinkTask extends SinkTask {
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+    // NOTE: Handle potential multiple invocations of flush() by treating map entries as Optional,
+    // since the map may have already been cleared in a prior call.
     currentOffsets.forEach(
         (topicPartition, offsetAndMetadata) ->
-            flushTopicPartitionWriter(topicPartitionWriters.get(topicPartition), topicPartition));
+            Optional.ofNullable(topicPartitionWriters.get(topicPartition))
+                .ifPresent(writer -> flushTopicPartitionWriter(writer, topicPartition)));
   }
 
   @Override


### PR DESCRIPTION
Summary
---
In some cases, the flush method of a task could be invoked multiple times, leading to a `NullPointerException` when attempting to close a non-existent writer.
This has been fixed by modifying the logic so that the close method is only called if the corresponding writer exists.