### PR TITLE
Fix NullPointerException on flush

### DIFF
--- a/src/test/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTaskTest.java
+++ b/src/test/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTaskTest.java
@@ -140,6 +140,16 @@ class BigqueryStorageWriteSinkTaskTest {
   }
 
   @Test
+  void testFlushWhenTaskClosed() {
+    setUpTask();
+
+    task.close(List.of(new TopicPartition(topicName, 0)));
+    task.flush(Map.of(new TopicPartition(topicName, 0), new OffsetAndMetadata(0)));
+
+    verify(mockedWriter, never()).write();
+  }
+
+  @Test
   void testPreCommit() {
     setUpTask();
 


### PR DESCRIPTION
# Summary

This PR fixes a NullPointerException that could occur during flush when no partitions are assigned.

# Issue

In certain scenarios, `flush()` is invoked even though no partitions are assigned.
As a result, `topicPartitionWriter` may be null, which leads to the following error:

```
java.lang.NullPointerException: Cannot invoke "com.reproio.kafka.connect.bigquery.BigqueryStreamWriter.write()" because "topicPartitionWriter" is null
	at com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask.flushTopicPartitionWriter(BigqueryStorageWriteSinkTask.java:118)
	at com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask.lambda$flush$5(BigqueryStorageWriteSinkTask.java:136)
	at java.base/java.util.HashMap.forEach(Unknown Source)
	at com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask.flush(BigqueryStorageWriteSinkTask.java:134)
	at com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask.preCommit(BigqueryStorageWriteSinkTask.java:142)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.commitOffsets(WorkerSinkTask.java:430)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.closePartitions(WorkerSinkTask.java:670)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.closeAllPartitions(WorkerSinkTask.java:665)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:217)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:226)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:281)
	at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:238)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

# Scenario

This issue happens in the following sequence:

1. A rebalance is triggered.  
2. The assigned partitions are revoked, offsets are committed, and then the [BigqueryStorageWriteSinkTask#close()](https://github.com/joker1007/kafka-connect-bigquery-storage-write/blob/4a0d1b6d3ff682d9e19167985610743e6c8f6c92/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java#L247) is executed, which clears `topicPartitionWriters`.
3. Before the rebalance completes, tasks are stopped.  
4. `WorkerSinkTask#closeAllPartitions()` is called([ref](https://github.com/apache/kafka/blob/3.9.0/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L214)), and offsets are committed again.  
5. During `flush()`, it attempts to access `topicPartitionWriters` that has already been cleared, causing a `NullPointerException`.
