### PR TITLE
Handle StorageException

### DIFF
--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStorageWriteSinkTask.java
@@ -210,9 +210,9 @@ public class BigqueryStorageWriteSinkTask extends SinkTask {
       topicPartitionRetryBoundaries.add(appendContext.getLastKafkaOffset());
       log.error("AppendContext has error", appendContext.getError());
       log.error(
-          "PreCommit for AppendContext is failed, a record in corruptedRowOffsets is ignored next retry: {corruptedRowOffsets={}, storageErrorCode={}}}",
+          "PreCommit for AppendContext is failed, a record in corruptedRowOffsets is ignored next retry: {corruptedRowOffsets={}, grpcErrorCode={}}}",
           corruptedRowOffsets,
-          appendContext.getStorageErrorCode());
+          appendContext.getGrpcStatusCode());
       if (appendContext.hasUnretryableError()) {
         log.error(
             "Unretryable error is occured: {topic={}, partition={}, from={}, to={}}",

--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
@@ -131,7 +131,7 @@ public class BigqueryStreamWriter implements Closeable {
       this.storageException = Exceptions.toStorageException(error);
     }
 
-    public Code getStorageErrorCode() {
+    public Code getGrpcStatusCode() {
       return storageException == null ? Code.UNKNOWN : storageException.getStatus().getCode();
     }
 
@@ -149,15 +149,17 @@ public class BigqueryStreamWriter implements Closeable {
     }
 
     public boolean hasUnretryableError() {
-      return error != null && !RETRIABLE_ERROR_CODES.contains(getStorageErrorCode());
+      return error != null && !RETRIABLE_ERROR_CODES.contains(getGrpcStatusCode());
     }
 
     public boolean isAlreadyExists() {
-      return getStorageErrorCode() == Code.ALREADY_EXISTS;
+      return getGrpcStatusCode() == Code.ALREADY_EXISTS
+          || storageException instanceof Exceptions.OffsetAlreadyExists;
     }
 
     public boolean isOutOfRange() {
-      return getStorageErrorCode() == Code.OUT_OF_RANGE;
+      return getGrpcStatusCode() == Code.OUT_OF_RANGE
+          || storageException instanceof Exceptions.OffsetOutOfRange;
     }
 
     public List<Long> corruptedRowKafkaOffsets() {


### PR DESCRIPTION
Added a check using StorageException.
Without this fix, `OffsetAlreadyExists` is not ignored. Below is the stack trace from that time.

```
ERROR AppendContext has error (com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask)
com.google.cloud.bigquery.storage.v1.Exceptions$OffsetAlreadyExists: ALREADY_EXISTS: The offset is within stream, expected offset 70090964, received 70089964 Entity: ...snip...
	at com.google.cloud.bigquery.storage.v1.Exceptions.toStorageException(Exceptions.java:203)
	at com.google.cloud.bigquery.storage.v1.ConnectionWorker.lambda$requestCallback$1(ConnectionWorker.java:1214)	
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)	
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```