### PR TITLE
Remove unnecessary `toStorageException` call in AppendContext#setError

### DIFF
--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
@@ -128,7 +128,9 @@ public class BigqueryStreamWriter implements Closeable {
 
     public void setError(Throwable error) {
       this.error = error;
-      this.storageException = Exceptions.toStorageException(error);
+      if (error instanceof StorageException) {
+        this.storageException = (StorageException) error;
+      }
     }
 
     public Code getGrpcStatusCode() {


### PR DESCRIPTION
The `setError` argument is already a StorageException, so calling `toStorageException` might end up setting it to null.

The following error log shows that the argument to `setError` is a StorageException.
The error output here is before the conversion with `toStorageException`, and `OffsetAlreadyExists` is a subclass of StorageException.
```
ERROR AppendContext has error (com.reproio.kafka.connect.bigquery.BigqueryStorageWriteSinkTask)
com.google.cloud.bigquery.storage.v1.Exceptions$OffsetAlreadyExists: ALREADY_EXISTS: The offset is within stream, expected offset 70090964, received 70089964 Entity: ...snip...
	at com.google.cloud.bigquery.storage.v1.Exceptions.toStorageException(Exceptions.java:203)
	at com.google.cloud.bigquery.storage.v1.ConnectionWorker.lambda$requestCallback$1(ConnectionWorker.java:1214)	
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)	
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```