### PR TITLE
Add exception class name to log output

### DIFF
--- a/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
+++ b/src/main/java/com/reproio/kafka/connect/bigquery/BigqueryStreamWriter.java
@@ -360,7 +360,7 @@ public class BigqueryStreamWriter implements Closeable {
 
     @Override
     public void onFailure(Throwable t) {
-      log.error("Failed to write rows", t);
+      log.error("Failed to write rows: {}", t.getClass().getName(), t);
       context.setError(t);
       done();
     }


### PR DESCRIPTION
We scan error logs to trigger alert notification. However, there are cases, where we don't want to send a notification even if write fails (e.g. `OffsetAlreadyExists`).
To handle this, we'd like to include the exception class name in the same log line.